### PR TITLE
Add NumPy v2 compatibility

### DIFF
--- a/dict_hash/dict_hash.py
+++ b/dict_hash/dict_hash.py
@@ -132,7 +132,13 @@ def _convert(
         if isinstance(data, float_np_types):
             return float(data)
 
-        if isinstance(data, (np.str_, np.string_)):
+        # If the given object is a numpy string, we convert it to a python string.
+        try:
+            string_np_types = (np.str_, np.bytes_)
+        except AttributeError:
+            string_np_types = (np.str_, np.string_)
+
+        if isinstance(data, string_np_types):
             return str(data)
 
     # If the given data is a simple object such as a string, an integer

--- a/dict_hash/dict_hash.py
+++ b/dict_hash/dict_hash.py
@@ -122,7 +122,14 @@ def _convert(
             return int(data)
 
         # If the given object is a numpy float, we convert it to a python float.
-        if isinstance(data, (np.float64, np.float32, np.float16, np.float_)):
+        float_np_types = (np.float64, np.float32, np.float16)
+
+        try:
+            float_np_types = (*float_np_types, np.float_)
+        except AttributeError:
+            pass
+
+        if isinstance(data, float_np_types):
             return float(data)
 
         if isinstance(data, (np.str_, np.string_)):


### PR DESCRIPTION
Fixes:

```
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.. Did you mean: 'float16'?
```

and

```
AttributeError: `np.string_` was removed in the NumPy 2.0 release. Use `np.bytes_` instead.. Did you mean: 'strings'?
```

When used with NumPy v2+.

https://numpy.org/devdocs/release/2.0.0-notes.html#numpy-2-0-python-api-removals

